### PR TITLE
Added extern definition to jetsonGPIO.h

### DIFF
--- a/jetsonGPIO.h
+++ b/jetsonGPIO.h
@@ -42,7 +42,11 @@
  /****************************************************************
  * Constants
  ****************************************************************/
- 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+	
 #define SYSFS_GPIO_DIR "/sys/class/gpio"
 #define POLL_TIMEOUT (3 * 1000) /* 3 seconds */
 #define MAX_BUF 64
@@ -96,6 +100,8 @@ int gpioOpen ( jetsonGPIO gpio ) ;
 int gpioClose ( int fileDescriptor ) ;
 int gpioActiveLow ( jetsonGPIO gpio, unsigned int value ) ;
 
-
+#ifdef __cplusplus
+}
+#endif
 
 #endif // JETSONGPIO_H_


### PR DESCRIPTION
This will allow you to link jetsonGPIO.h / jetsonGPIO.c into a C++ program with CMake